### PR TITLE
Add multi-platform support for script to toggle Wi-Fi power

### DIFF
--- a/wifitoggle
+++ b/wifitoggle
@@ -1,21 +1,32 @@
 #!/usr/bin/env bash
-# This is a macOS-specific shell script to toggle Wi-Fi power
+# This is a shell script to toggle Wi-Fi power
 # Written and tested on Sierra (macOS 10.12.5 and 10.12.6)
+# and Fedora 27
 
-# Set full path to "networksetup" command
-NSCMD="/usr/sbin/networksetup"
-
-# Set Wi-Fi interface name (assumes en0)
-# Swap commented lines around if Wi-Fi interface is en1
-# IFACE="en1"
-IFACE="en0"
-
-# Get the current Wi-Fi power status using networksetup
-STATUS=$($NSCMD -getairportpower $IFACE | cut -d' ' -f4)
-
-# Evaluate current status and toggle power
-if [[ $STATUS == 'On' ]]; then
-    $NSCMD -setairportpower $IFACE off
-elif [[ $STATUS == 'Off' ]]; then
-    $NSCMD -setairportpower $IFACE on
-fi
+case "$OSTYPE" in
+    darwin*)
+        CMD="/usr/bin/networksetup"
+        # Swap commented lines around if Wi-Fi interface is en1
+        # IFACE="en1"
+        IFACE="en0"
+        # Get the current Wi-Fi power status using networksetup
+        STATUS=$($CMD -getairportpower $IFACE | cut -d' ' -f4)
+        # Evaluate current status and toggle power
+        if [[ $STATUS == 'On' ]]; then
+            $CMD -setairportpower $IFACE off
+        elif [[ $STATUS == 'Off' ]]; then
+            $CMD -setairportpower $IFACE on
+        fi
+        ;;
+    linux*)
+        CMD="/usr/bin/nmcli radio wifi"
+        # Get the current Wi-Fi power status using nmcli
+        STATUS=$($CMD)
+        # Evaluate current status and toggle power
+        if [[ $STATUS == 'enabled' ]]; then
+            $CMD off
+        else
+            $CMD on
+        fi
+        ;;
+esac

--- a/wifitoggle
+++ b/wifitoggle
@@ -5,7 +5,7 @@
 
 case "$OSTYPE" in
     darwin*)
-        CMD="/usr/bin/networksetup"
+        CMD="/usr/sbin/networksetup"
         # Swap commented lines around if Wi-Fi interface is en1
         # IFACE="en1"
         IFACE="en0"

--- a/wifitoggle
+++ b/wifitoggle
@@ -6,9 +6,8 @@
 case "$OSTYPE" in
     darwin*)
         CMD="/usr/sbin/networksetup"
-        # Swap commented lines around if Wi-Fi interface is en1
-        # IFACE="en1"
-        IFACE="en0"
+        # Determine which interface is the Wi-Fi interface
+        IFACE=$($CMD -listallhardwareports | grep -A1 'Wi-Fi' | awk '/Device/ {print $2}')
         # Get the current Wi-Fi power status using networksetup
         STATUS=$($CMD -getairportpower $IFACE | cut -d' ' -f4)
         # Evaluate current status and toggle power


### PR DESCRIPTION
The original script was specific to macOS. This PR adds support to operate on both macOS and Fedora 27 (will probably work with other Linux distributions as well that use Network Manager). This PR also adds support for programmatically determining the Wi-Fi interface on macOS-based systems (eliminates the need to hard-code the Wi-Fi interface name in the script).