### PR TITLE
Add multi-platform support for files command

### DIFF
--- a/files
+++ b/files
@@ -47,6 +47,11 @@ if [ ! -d "$CWD" ]; then
     exit
 fi
 
-# Open a Nautilus window at the current working directory
-# It is assumed that Nautilus is in the search path
-nohup nautilus --new-window --no-desktop file://$CWD &> /dev/null &
+# Open a filem manager window at the current working directory
+# Checks for macOS (Darwin) and uses open command;
+# otherwise, assumes Linux and Nautilus
+if [[ $(uname -a) == *Darwin* ]]; then
+    open $CWD
+else
+    nohup nautilus --new-window --no-desktop file://$CWD &> /dev/null &
+fi

--- a/files
+++ b/files
@@ -10,7 +10,7 @@ if [ "$#" -ne 1 ]; then
     echo
     echo $HELP
     echo
-    exit
+    exit 1
 fi
 
 # Assign CWD variable to the parameter supplied by the user;
@@ -18,40 +18,51 @@ fi
 if [ "$#" -eq 0 ]; then
     CWD=$(pwd)
 else
-    CWD=$1
+    CWD="$1"
 fi
 
 # If the user supplied "--help", then provide help text
 if [ "$CWD" = "--help" ]; then
     echo $HELP
     echo
-    exit
+    exit 0
 fi
 
-# Catch instances where user supplies "." as path (to open current directory)
-if [ "$CWD" = "." ]; then
-    CWD=$(pwd)
-fi
+# Try to catch special instances
+case "$CWD" in
+    '.') # User supplies "." to open current directory
+        CWD=$(pwd)
+        ;;
+    '..') # User supplies ".." to open parent directory
+        echo "Double-dot syntax is not yet supported; please supply path to parent directory"
+        echo
+        exit 1
+        ;;
+esac
 
-# Catch instances where user supplies ".." as path (to open parent directory)
-if [ "$CWD" = ".." ]; then
-    echo "Double-dot syntax not yet supported; please supply path to parent directory"
-    echo
-    exit
+# Check for case where user supplies a subdirectory of the current directory
+# (if parameter specified doesn't start with a slash it is assumed to be a
+# subdirectory of the current directory)
+testchar=$(echo "$CWD" | cut -c 1 -)
+if [ ! $testchar = '/' ]; then
+    CWD="$(pwd)/$CWD"
 fi
 
 # Check that the path supplied as a parameter is valid
 if [ ! -d "$CWD" ]; then
     echo "Invalid path specified; please provide a valid path"
     echo
-    exit
+    exit 1
 fi
 
-# Open a filem manager window at the current working directory
+# Debugging
+#echo "$CWD"
+
+# Open a filem manager window at the specified directory
 # Checks for macOS (Darwin) and uses open command;
-# otherwise, assumes Linux and Nautilus
+# otherwise, assumes Linux/GNOME and presence of xdg-open command
 if [[ $(uname -a) == *Darwin* ]]; then
-    open $CWD
+    /usr/bin/open "$CWD"
 else
-    nohup nautilus --new-window --no-desktop file://$CWD &> /dev/null &
+    /usr/bin/xdg-open "$CWD"
 fi


### PR DESCRIPTION
To bring greater consistency to my mixed macOS/Linux environment, this PR adds multi-platform support for the `files` command. This will allow me to use the `files` command in the same way on both macOS as well as Linux (to invoke a particular directory in the file manager, either Finder or Nautilus).