### PR TITLE
Contributing bash completion file

### DIFF
--- a/kcs.bash_completion
+++ b/kcs.bash_completion
@@ -1,0 +1,15 @@
+#/usr/bin/env bash
+
+_kcs_completions()
+{
+
+  # Create list of possible completions
+  # + none
+  # - config
+  COMPREPLY=($(compgen -W "none $(kcs list | sed 's/^config //' )" "${COMP_WORDS[1]}"))
+}
+
+# Allow dynamic recreation of completion list for kcs:
+complete -F _kcs_completions kcs
+
+


### PR DESCRIPTION
kcs is a nice little utility which merits bash completion.

This script should be sourced as
    source ksc.bash_completion

From then on we can bash autocomplete
e.g.
    $ ksc <tab>
    config.minikube config.dockerdesktop none
    $ ksc c<tab>
    config.minikube config.dockerdesktop
    $ ksc config.m<tab>    # autocompletes to ksc config.minikube