### PR TITLE
Look recursively for kubeconfig files

### DIFF
--- a/kcs
+++ b/kcs
@@ -38,7 +38,7 @@ fi
 
 # If user specified 'list', then list the files in the ~/.kube directory
 if [ "$KCFG" == "list" ]; then
-    echo $(ls -l "$KUBEDIR" | tail -n +2 | grep -v '^d' | awk '{print $9}')
+    echo $(grep -lr ^clusters: $KUBEDIR | sed -e "s-$KUBEDIR/--")
     exit 0
 fi
 


### PR DESCRIPTION
This suggested change allows "list" to
- detect candidate "kubeconfig" files based on appearance of "^clusters:" within the file (slightly better than just existence of a file)
- looks recursively within $KUBEDIR subdirs

Is this useful?