### PR TITLE
Add new Zettelkasten-related script

### DIFF
--- a/zk
+++ b/zk
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# This is a shell script to simplify/automate certain Zettelkasten-related
+# tasks, such as creating Zettels or searching the Zettelkasten
+
+# Set some variables for use later
+ZKUID="$(date +%Y%m%d%H%M%S)"
+ZKPATH="$HOME/Sync/Zettelkasten"
+HELP="Usage: zk [ new | search | edit | open ]"
+
+# If the user supplied "--help", then provide help text
+if [ "$1" = "--help" ]; then
+    echo -e "$HELP\n"
+    exit 0
+fi
+
+# Set certain OS-specific variables
+case "$OSTYPE" in
+    darwin*)
+        CODE="/usr/local/bin/code"
+        ;;
+    linux*)
+        CODE="/usr/bin/code"
+        ;;
+    *)
+        echo -e "This script is not supported on this operating system\n"
+        exit 1
+        ;;
+esac
+
+# Test to ensure the user passed at least one parameter (the subcommand)
+if [ ! "$#" -ge 1 ]; then
+    echo -e "No valid subcommand was provided, exiting\n"
+    echo $HELP
+    exit 1
+fi
+
+# Parse the command line to get the subcommand
+SUBCMD="$1"
+
+# Switch into the Zettelkasten directory for the remainder of the script
+cd "$ZKPATH"
+
+# Take action based on commands and parameters provided by the user
+case "$SUBCMD" in
+    new)
+        # Test to ensure the user passed a name parameter
+        if [ "$#" -ne 2 ]; then
+            echo -e "An invalid name was specified for the new zettel, exiting\n"
+            echo -e "Usage: zk new [name-of-zettel]"
+            exit 1
+        fi
+        # Parse out the command line further
+        NAME="$2"
+        # Calculate correct file name
+        ZETTELNAME="$ZKUID-$NAME.md"
+        # Create file with initial contents
+        touch "$ZETTELNAME"
+        echo "$ZKUID-$NAME" >> "$ZETTELNAME"
+        # Pass off to the editor
+        $CODE "$ZKPATH/$ZETTELNAME"
+        ;;
+    search)
+        # Test to ensure the user passed only the search subcommand
+        if [ "$#" -ne 1 ]; then
+            echo -e "Only the search subcommand should be provided\n"
+            echo -e "Usage: zk search"
+            exit 1
+        fi
+        # Use fd to list all files, pass that to fzf, and then open in editor
+        fd -t f . "$ZKPATH" | fzf | xargs bat
+        ;;
+    edit)
+        # Test to ensure the user passed only the edit subcommand
+        if [ "$#" -ne 1 ]; then
+            echo -e "Only the edit subcommand should be provided\n"
+            echo -e "Usage: zk edit"
+            exit 1
+        fi
+        # Use fd to list all files, pass that to fzf, and then open in editor
+        fd -t f . "$ZKPATH" | fzf | xargs code "$ZKPATH" -g
+        ;;
+    open)
+        # Open the Zettelkasten folder in the editor
+        $CODE "$ZKPATH"
+        ;;
+    *)
+        # Present an error about an unsupported subcommand
+        echo -e "No valid subcommand was provided, exiting\n"
+        echo -e "$HELP\n"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
This PR adds a `zk` script that can be used to help manage the Zettelkasten by making it easier to create new notes, search for notes, edit a note, or open the entire Zettelkasten. It has been tested only on Linux so far.